### PR TITLE
Adjustment: Source Code: Zywin 1.1.1 -> 1.1.2-stable-release

### DIFF
--- a/pkg/v2/zywin/src/winehelper.cpp
+++ b/pkg/v2/zywin/src/winehelper.cpp
@@ -339,15 +339,22 @@ void WineHandler::execIso(const std::filesystem::path &file) {
         // checks of the input is a number
         if(isDigitOnly(option)) {
 
-
             try {
                 // checks if the selected option is at the right bound
-                executables.at(std::stoi(option));
+                // made a change here where i placed the return value of at() in a const variable that will never be used
+                // to remove g++ warnings
+                const auto &x = executables.at(std::stoi(option));
+
+                // damn the g++ compiler still flags a wanring despite writing [[maybe_unsused]] so 
+                // i'll just cast the variable to nothing
+                (void)x;
+
+
                 execExe(executables[std::stoi(option)], file);
             
-            } catch(std::out_of_range) {
+            } catch(std::out_of_range &e) {
 
-                std::cout <<  BRIGHT_RED "\nYour selected option is not in the list\n" RESET;
+                std::cout <<  BRIGHT_RED "\nYour selected option is not in the list\n" << e.what() << RESET "\n";
                 exit(EXIT_FAILURE);
             }
         } else {

--- a/pkg/v2/zywin/src/winehelper.hpp
+++ b/pkg/v2/zywin/src/winehelper.hpp
@@ -37,14 +37,14 @@ public:
 private:
 
     // formatting file name into a valid prefix path
-    std::string sanitizeFileName(const std::filesystem::path &file);
+    static std::string sanitizeFileName(const std::filesystem::path &file);
 
     // Generates a wine prefix
-    std::filesystem::path getWinePrefix(const std::filesystem::path &file);
+    static std::filesystem::path getWinePrefix(const std::filesystem::path &file);
 
     // ensures that the wineprefix is generated
-    void ensureWinePrefix(const std::filesystem::path &prefix);
+    static void ensureWinePrefix(const std::filesystem::path &prefix);
     
     // Class member responsible of traversing an entire directory after extracting from an iso to find executables
-    std::vector<std::filesystem::path> findExecutables(const std::filesystem::path &dir);
+    static std::vector<std::filesystem::path> findExecutables(const std::filesystem::path &dir);
 };

--- a/pkg/v2/zywin/zywin/DEBIAN/control
+++ b/pkg/v2/zywin/zywin/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: zywin
-Version: 1.1.1-stable-release
+Version: 1.1.2-stable-release
 Section: utils
 Priority: optional
 Architecture: all


### PR DESCRIPTION
Adjustment: Source Code: Zywin: Adjusted how the return value of std::vector .at() member inside execIso is handled to remove compiler warnings at compilation, turned std::string sanitizeFileName, std::filesystem::path getWinePrefix, void ensureWinePrefix, std::vector<std::filesystem::path> findExecutables to static class member